### PR TITLE
docs: add Maven Central dependency instructions for v2.0.0

### DIFF
--- a/essentials/requirements.md
+++ b/essentials/requirements.md
@@ -13,5 +13,44 @@ both by [Bruce Schneier](https://www.schneier.com/).
 
 ## Setup
 
-Grab the [latest package release](https://jitpack.io/#mcaserta/bruce) from
-JitPack.
+Bruce 2.0.0 is available on [Maven Central](https://central.sonatype.com/artifact/com.mirkocaserta.bruce/bruce/2.0.0/overview).
+
+### Maven
+
+Add the following dependency to your `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>com.mirkocaserta.bruce</groupId>
+    <artifactId>bruce</artifactId>
+    <version>2.0.0</version>
+</dependency>
+```
+
+### Gradle (Kotlin DSL)
+
+Add the following to your `build.gradle.kts`:
+
+```kotlin
+implementation("com.mirkocaserta.bruce:bruce:2.0.0")
+```
+
+### Gradle (Groovy DSL)
+
+Add the following to your `build.gradle`:
+
+```groovy
+implementation 'com.mirkocaserta.bruce:bruce:2.0.0'
+```
+
+### Scala SBT
+
+```scala
+libraryDependencies += "com.mirkocaserta.bruce" % "bruce" % "2.0.0"
+```
+
+### Apache Ivy
+
+```xml
+<dependency org="com.mirkocaserta.bruce" name="bruce" rev="2.0.0"/>
+```


### PR DESCRIPTION
Replace JitPack setup with Maven Central coordinates for the 2.0.0
release, covering Maven, Gradle (Kotlin and Groovy DSL), SBT, and Ivy.

https://claude.ai/code/session_01RYTJtJuNS2qU7idhmq2h4w